### PR TITLE
fix: Slidevスライドがデプロイ一覧に表示されない問題を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
             # Slidev: has components/ directory or "theme:" in frontmatter
             elif [ -d "$dir/components" ] || grep -qm1 "^theme:" "$mdfile" 2>/dev/null; then
               echo "=== Building Slidev: $dir ==="
-              npx slidev build "$mdfile" --base "/$REPO_NAME/$dir/" --out "dist/$dir"
+              npx slidev build "$mdfile" --base "/$REPO_NAME/$dir/" --out "$(pwd)/dist/$dir"
 
             else
               echo "Skipping $dir (unrecognized type)"


### PR DESCRIPTION
## 問題

Slidevの `--out` オプションはスライドファイルが置かれたディレクトリからの相対パスとして解釈される。

そのため `--out "dist/20260304_emconf"` と指定すると、実際の出力先が `20260304_emconf/dist/20260304_emconf/` になっていた。

結果として:
- ビルドログには `dist/20260304_emconf/index.html` と表示されるが、これはスライドのディレクトリからの相対パス
- インデックス生成スクリプトがリポジトリルートの `dist/` を走査しても Slidev の出力を見つけられない
- 一覧ページに Marp スライドしか表示されない

## 修正

`$(pwd)/dist/$dir` の絶対パスを指定することで、Slidev の出力先をリポジトリルートの `dist/` 以下に正しく配置する。

## Test plan

- [ ] mainへのmerge後、Actionsが正常完了することを確認
- [ ] `https://kzk-maeda.github.io/event-slides/` に Slidev スライドが表示されることを確認
- [ ] `https://kzk-maeda.github.io/event-slides/20260304_emconf/` が404にならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)