### PR TITLE
fix: SlidevスライドのページURL直接アクセスと画像読み込みの修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,7 @@ jobs:
             elif [ -d "$dir/components" ] || grep -qm1 "^theme:" "$mdfile" 2>/dev/null; then
               echo "=== Building Slidev: $dir ==="
               npx slidev build "$mdfile" --base "/$REPO_NAME/$dir/" --out "dist/$dir"
+              [ -d "$dir/images" ] && cp -r "$dir/images" "dist/$dir/"
 
             else
               echo "Skipping $dir (unrecognized type)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,8 +58,8 @@ jobs:
             # Slidev: has components/ directory or "theme:" in frontmatter
             elif [ -d "$dir/components" ] || grep -qm1 "^theme:" "$mdfile" 2>/dev/null; then
               echo "=== Building Slidev: $dir ==="
-              npx slidev build "$mdfile" --base "/$REPO_NAME/$dir/" --out "dist/$dir"
-              [ -d "$dir/images" ] && cp -r "$dir/images" "dist/$dir/"
+              npx slidev build "$mdfile" --base "/$REPO_NAME/$dir/" --out "$(pwd)/dist/$dir"
+              [ -d "$dir/images" ] && cp -r "$dir/images" "$(pwd)/dist/$dir/"
 
             else
               echo "Skipping $dir (unrecognized type)"

--- a/20260304_emconf/slide.md
+++ b/20260304_emconf/slide.md
@@ -7,6 +7,7 @@ drawings:
   persist: false
 transition: slide-left
 mdc: true
+routerMode: hash
 ---
 
 # 経営と会計とエンジニアリング


### PR DESCRIPTION
## 修正内容

### 1. ページURL直接アクセス（404）の修正

GitHub Pages は SPA のサーバーサイドルーティングをサポートしないため、`/20260304_emconf/8` のような URL に直接アクセスすると 404 になる。

`routerMode: hash` を追加することでハッシュベースのルーティング（`/20260304_emconf/#/8`）に変更し、直接アクセスが可能になる。

### 2. コンポーネント経由の画像読み込み修正

Vite は Vue コンポーネントに props として渡された画像パス（`image-src="./images/cf_01.svg"` など）を静的アセットとして処理しない。そのため、ビルド後の `dist/` にコピーされず画像が表示されない。

Slidev ビルド後に `images/` を `dist/` にコピーすることで修正。

## Test plan

- [ ] mainへのmerge後、`https://kzk-maeda.github.io/event-slides/20260304_emconf/` が表示される
- [ ] `https://kzk-maeda.github.io/event-slides/20260304_emconf/#/8` で直接アクセスできる
- [ ] CFパターン図などの画像が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)