### PR TITLE
fix: Slidevビルドをスライドディレクトリ内で実行してカスタムスタイルを適用

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,8 +58,9 @@ jobs:
             # Slidev: has components/ directory or "theme:" in frontmatter
             elif [ -d "$dir/components" ] || grep -qm1 "^theme:" "$mdfile" 2>/dev/null; then
               echo "=== Building Slidev: $dir ==="
-              npx slidev build "$mdfile" --base "/$REPO_NAME/$dir/" --out "$(pwd)/dist/$dir"
-              [ -d "$dir/images" ] && cp -r "$dir/images" "$(pwd)/dist/$dir/"
+              OUTDIR="$(pwd)/dist/$dir"
+              (cd "$dir" && npx slidev build "$(basename "$mdfile")" --base "/$REPO_NAME/$dir/" --out "$OUTDIR")
+              [ -d "$dir/images" ] && cp -r "$dir/images" "$OUTDIR/"
             else
               echo "Skipping $dir (unrecognized type)"
             fi


### PR DESCRIPTION
## 問題

リポジトリルートから `npx slidev build "20260304_emconf/slide.md"` を実行すると、Slidev の root がリポジトリルートになる。そのため `styles/index.css` が見つからず、カスタムスタイル（`.split-card`、`.agenda-slide` など）が本番環境で適用されない。

ローカルではスライドディレクトリ内から実行するため問題なく動作していた。

## 修正

サブシェルで `cd "$dir"` してからビルドすることで、Slidev の root をスライドディレクトリに設定する。

```bash
OUTDIR="$(pwd)/dist/$dir"
(cd "$dir" && npx slidev build "$(basename "$mdfile")" --base "..." --out "$OUTDIR")
```

## Test plan

- [ ] mainへのmerge後、`https://kzk-maeda.github.io/event-slides/20260304_emconf/#/8` のカードスタイルが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)