### PR TITLE
fix: Slidevスライドのスタイル読み込みとレスポンシブ対応を修正

### DIFF
--- a/20260304_emconf/setup/main.ts
+++ b/20260304_emconf/setup/main.ts
@@ -1,0 +1,6 @@
+import { defineAppSetup } from '@slidev/types'
+import '../styles/index.css'
+
+export default defineAppSetup(() => {
+  // Setup code here
+})

--- a/20260304_emconf/styles/index.css
+++ b/20260304_emconf/styles/index.css
@@ -104,8 +104,8 @@
 }
 
 .accent {
-  color: var(--atama-primary);
-  font-weight: 700;
+  color: var(--atama-primary) !important;
+  font-weight: 700 !important;
 }
 
 .slidev-layout:not(.title-slide):not(.door-slide)::before {
@@ -602,6 +602,29 @@
   .cf-card {
     min-height: 0;
     text-align: left;
+  }
+
+  /* two-cols-header layout responsive */
+  .slidev-layout.two-cols-header .grid,
+  .slidev-layout.two-cols-header .slidev-layout,
+  .slidev-layout[class*="two-cols"] {
+    display: flex !important;
+    flex-direction: column !important;
+  }
+
+  .slidev-layout.two-cols-header .left,
+  .slidev-layout.two-cols-header .right,
+  .slidev-layout.two-cols-header .col-left,
+  .slidev-layout.two-cols-header .col-right {
+    width: 100% !important;
+    margin: 0 !important;
+  }
+
+  .split-card-slide .left,
+  .split-card-slide .right,
+  .col-left.split-card-slide,
+  .col-right.split-card-slide {
+    transform: none !important;
   }
 }
 


### PR DESCRIPTION
## 概要
GitHub Pagesにデプロイされたスライドのスタイル問題を修正

## 問題点
- `.accent`クラスのfont-weightが正しく適用されていない
- カードコンポーネント(スライド#8)のレイアウトが崩れている
- スマホ表示時にレイアウトが崩れる

## 修正内容
1. **setup/main.tsの追加**: Slidevビルド時にカスタムスタイルを確実に読み込む
2. **.accentクラスの改善**: `!important`を追加してスタイル優先度を向上
3. **レスポンシブ対応**: two-cols-headerレイアウトのスマホ対応を改善

## 検証方法
デプロイ後、以下を確認:
- スライド#7: `.accent`クラスの文字が太字(font-weight: 700)で表示される
- スライド#8: 左右2つのカードが正しく表示される
- スマホ表示: 2カラムレイアウトが縦並びになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)