### PR TITLE
fix: タイトルサイズ・カードレイアウト・テーブル内accentクラスを修正

### DIFF
--- a/20260304_emconf/slide.md
+++ b/20260304_emconf/slide.md
@@ -92,13 +92,14 @@ class: text-center
 考え方のフレームと実体験の両面からお話しします
 
 ---
-layout: two-cols-header
+layout: default
 class: split-card-slide
 ---
 
 # 理想と現実のギャップ
 
-::left::
+<div class="grid grid-cols-2 gap-4 mt-4">
+<div>
 
 <div class="split-card split-card-ideal">
 
@@ -110,8 +111,7 @@ CEO/CFOから明確な方針が示される
 - 「来期はコスト削減フェーズなので、既存システムの効率化に集中を」
 
 </div>
-
-::right::
+<div>
 
 <v-click>
 
@@ -127,6 +127,8 @@ CEO/CFOから明確な方針が示される
 </div>
 
 </v-click>
+</div>
+</div>
 
 ---
 class: agenda-slide

--- a/20260304_emconf/slide.md
+++ b/20260304_emconf/slide.md
@@ -99,8 +99,8 @@ class: split-card-slide
 # 理想と現実のギャップ
 
 <div class="grid grid-cols-2 gap-4 mt-4">
-<div>
 
+<div>
 <div class="split-card split-card-ideal">
 
 ### 理想
@@ -111,8 +111,9 @@ CEO/CFOから明確な方針が示される
 - 「来期はコスト削減フェーズなので、既存システムの効率化に集中を」
 
 </div>
-<div>
+</div>
 
+<div>
 <v-click>
 
 <div class="split-card split-card-reality">
@@ -128,6 +129,7 @@ CEO/CFOから明確な方針が示される
 
 </v-click>
 </div>
+
 </div>
 
 ---

--- a/20260304_emconf/styles/index.css
+++ b/20260304_emconf/styles/index.css
@@ -108,6 +108,18 @@
   font-weight: 700 !important;
 }
 
+/* Ensure .accent works in tables and headings */
+td .accent,
+th .accent,
+h1 .accent,
+h2 .accent,
+h3 .accent,
+h4 .accent,
+p .accent {
+  color: var(--atama-primary) !important;
+  font-weight: 700 !important;
+}
+
 .slidev-layout:not(.title-slide):not(.door-slide)::before {
   content: "";
   position: absolute;
@@ -182,7 +194,7 @@
 
 .slidev-layout.title-slide h1 {
   position: relative;
-  font-size: 2.45rem;
+  font-size: 1.95rem;
   font-weight: 700;
   line-height: 1.45;
   letter-spacing: 0.04em;
@@ -464,7 +476,8 @@
 .split-card-slide .left,
 .split-card-slide .right,
 .col-left.split-card-slide,
-.col-right.split-card-slide {
+.col-right.split-card-slide,
+.split-card-slide .grid > div {
   display: flex;
   align-items: flex-start;
   justify-content: center;

--- a/20260304_emconf/styles/index.css
+++ b/20260304_emconf/styles/index.css
@@ -194,7 +194,7 @@ p .accent {
 
 .slidev-layout.title-slide h1 {
   position: relative;
-  font-size: 1.95rem;
+  font-size: 1.95rem !important;
   font-weight: 700;
   line-height: 1.45;
   letter-spacing: 0.04em;


### PR DESCRIPTION
## 概要
PR #16で残っていた3つのスタイル問題を修正

## 修正内容

### 1. タイトルスライドのフォントサイズを縮小
- **問題**: タイトルスライドの文字が大きすぎた
- **修正**: h1のfont-sizeを2.45rem→1.95remに変更

### 2. カードコンポーネントのレイアウトを修正
- **問題**: スライド#8で右側のカードが表示されない
- **原因**: `two-cols-header`レイアウトがSlidevのデフォルトに存在しない
- **修正**: `layout: default`に変更し、グリッドレイアウト(`grid grid-cols-2`)を使用

### 3. テーブル・見出し内の.accentクラスを修正
- **問題**: テーブルやh3要素内の`.accent`クラスが機能しない
- **修正**: より具体的なセレクタを追加 (`td .accent`, `th .accent`, `h3 .accent`など)

## 検証方法
デプロイ後、以下を確認:
- スライド#1: タイトルサイズが適切
- スライド#8: 左右2つのカードが正しく表示される
- スライド#16: テーブル内の`.accent`クラスが青緑色で太字表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)